### PR TITLE
Minor Improvements to Install Script; Updated the Packages

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -27,16 +27,16 @@
         - curl
         #- default-jdk
         - dkms
-        - eclipse
+        #- eclipse
         - emacs
-        - gnupg2
+        #- gnupg2
+        #- pgpgpg
         - graphviz
         - gthumb
         #- lynx
         #- octave
         - openssh-client
         - openssh-server
-        - pgpgpg
         #- racket
         - seahorse
         - stow
@@ -74,12 +74,19 @@
     # this playbook is run as root, so the apm command above creates a ~/.atom
     # owned by root, so the student user does not have permissions into it, and
     # Atom fails to load properly and shows a debug interface. This makes the
-    # directory owned by student, solving the problem.
+    # directory owned by {{ login }}, by default `student`, thus
+    # solving the problem.
     - name: .atom owned by user instead of root
       file:
         path: ~/.atom
         owner: "{{ login }}"
         group: "{{ login }}"
+
+    - name: Adding current user {{ login }} to groups
+      user:
+        name: "{{ login }}"
+        groups: sudo vboxsf
+        append: yes
 
     - name: source code control
       apt: name={{item}} state=present

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -24,7 +24,7 @@
         name: vboxsf
         gid: 999
         state: present
-    
+
     - name: kitchen sink packages
       apt: name={{item}} state=present
       with_items:
@@ -87,10 +87,10 @@
         owner: "{{ login }}"
         group: "{{ login }}"
 
-    - name: Adding current user {{ login }} to groups
+    - name: Adding current user {{ login }} to group vboxsf preemptively
       user:
         name: "{{ login }}"
-        groups: sudo vboxsf
+        groups: vboxsf
         append: yes
 
     - name: source code control

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -78,8 +78,8 @@
     - name: .atom owned by user instead of root
       file:
         path: ~/.atom
-        owner: {{ login }}
-        group: {{ login }}
+        owner: "{{ login }}"
+        group: "{{ login }}"
 
     - name: source code control
       apt: name={{item}} state=present

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -10,12 +10,12 @@
   remote_user: root
   tasks:
 
-    - name: update system packages
+    - name: Update repositories cache and update all packages to the latest version
       apt:
         update_cache: yes
         upgrade: dist
 
-    - name: remove obsolete packages
+    - name: Remove dependencies that are no longer required
       apt:
         autoremove: yes
 

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -19,6 +19,12 @@
       apt:
         autoremove: yes
 
+    - name: Ensure that the vboxsf group exists to premptively add the user to it.
+      group:
+        name: vboxsf
+        gid: 999
+        state: present
+    
     - name: kitchen sink packages
       apt: name={{item}} state=present
       with_items:

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -130,7 +130,8 @@
         - libssl-dev
         - lldb
         - meld
-        #- nlohmann-json-dev Not available for 16.04.4 LTS See https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=nlohmann-json-dev&searchon=names
+        # Not available for Ubuntu 16.04 LTS
+        - nlohmann-json-dev
         - scons
         - sqlite3
         - valgrind
@@ -270,7 +271,7 @@
   remote_user: root
   tasks:
 
-    - name: apt-get clean
-      command: apt-get clean
+    - name: apt clean
+      command: apt clean
     
 ...

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -130,7 +130,7 @@
         - libssl-dev
         - lldb
         - meld
-        - nlohmann-json-dev
+        #- nlohmann-json-dev Not available for 16.04.4 LTS See https://packages.ubuntu.com/search?suite=default&section=all&arch=any&keywords=nlohmann-json-dev&searchon=names
         - scons
         - sqlite3
         - valgrind

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -23,34 +23,28 @@
       apt: name={{item}} state=present
       with_items:
         - a2ps
-        - chromium-browser
-        - cifs-utils
+        #- cifs-utils
         - curl
-        - default-jdk
+        #- default-jdk
         - dkms
         - eclipse
         - emacs
-        - enigmail
-        - evolution
         - gnupg2
         - graphviz
         - gthumb
-        - lynx
-        - octave
+        #- lynx
+        #- octave
         - openssh-client
         - openssh-server
         - pgpgpg
-        - pidgin
-        - racket
+        #- racket
         - seahorse
         - stow
-        - thunderbird
-        - thunderbird-locale-en
         - vagrant
         - vim
         - xfce4-goodies
         - xfce4-weather-plugin
-        - zsh
+        - readline
 
 ###############################################################################
 # CPSC 120-121-131 official environment
@@ -84,8 +78,8 @@
     - name: .atom owned by user instead of root
       file:
         path: ~/.atom
-        owner: student
-        group: student
+        owner: {{ login }}
+        group: {{ login }}
 
     - name: source code control
       apt: name={{item}} state=present

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -44,7 +44,6 @@
         - vim
         - xfce4-goodies
         - xfce4-weather-plugin
-        - readline
 
 ###############################################################################
 # CPSC 120-121-131 official environment

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -137,6 +137,20 @@
         - valgrind
 
 ###############################################################################
+# Mikhail Gofman's Packages
+# point person: Mikhail Gofman
+###############################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: Mikhail Gofman's Packages
+      apt: name={{item}} state=present
+      with_items:
+        - tmate
+
+###############################################################################
 # CPSC 223J
 # point person: Floyd Holliday
 ###############################################################################

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -193,6 +193,24 @@
         - nasm
 
 ###############################################################################
+# CPSC 351
+# point person: Michael Shafae
+###############################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: 351 libraries
+      apt: name={{item}} state=present
+      with_items:
+        - libreadline-dev
+        - manpages-posix
+        - manpages-posix-dev
+        - glibc-doc
+
+
+###############################################################################
 # CPSC 484
 # point person: Michael Shafae, Kevin Wortman
 ###############################################################################

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -1,16 +1,30 @@
 #! /bin/bash
 
+TUFFIXYML_SRC="https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml"
+
+TUFFIXYML=/tmp/tuffix.$$.yml
+
 if (( EUID == 0 )); then
     echo "error: do not run tuffixize.sh as root"
     exit 1
 fi
 
+if [ $# > 0 ]; then
+  VMUSER=student
+else
+  VMUSER=${USER}
+fi
+
+if [ "${VMUSER}x" -eq "x" ]; then
+  echo "Environment missing USER variable; using student."
+  VMUSER=student
+fi
+
+
 sudo apt --yes install ansible wget
 
-wget https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml
+wget -o ${TUFFIXYML} ${TUFFIXYML_SRC}
 
-sudo ansible-playbook --inventory localhost, --connection local tuffix.yml
+sudo ansible-playbook --extra-vars="login=${VMUSER}" --inventory localhost, --connection local ${TUFFIXYML}
 
-rm -f tuffix.yml
-
-sudo chown -R $USER:$USER ~/.atom
+rm -f ${TUFFIXYML}

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -1,6 +1,9 @@
 #! /bin/bash
 
-TUFFIXYML_SRC="https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml"
+
+# Use  the default environment defined TUFFIXYML_SRC
+# (see bash (1) Parameter Expansion)
+TUFFIXYML_SRC=${TUFFIXYML_SRC:-"https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml"}
 
 TUFFIXYML=/tmp/tuffix.$$.yml
 

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -15,11 +15,12 @@ else
   VMUSER=${USER}
 fi
 
+VMUSER=${USER}
+
 if [ "${VMUSER}x" -eq "x" ]; then
   echo "Environment missing USER variable; using student."
   VMUSER=student
 fi
-
 
 sudo apt --yes install ansible wget
 

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -22,24 +22,31 @@ if [ "${VMUSER}x" == "x" ]; then
   VMUSER=student
 fi
 
+sudo apt-get --yes update
+sudo apt-get install --yes software-properties-common
+sudo apt-add-repository --yes ppa:ansible/ansible
+sudo apt-get --yes update
+sudo apt-get install --yes ansible
+sudo apt-get install --yes wget
 
-sudo apt --yes install ansible wget
 
-ANSIBLE_MAJOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 1 -d.`
-ANSIBLE_MINOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 2 -d.`
+#sudo apt --yes install ansible wget
+
+#ANSIBLE_MAJOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 1 -d.`
+#ANSIBLE_MINOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 2 -d.`
 
 # The tuffix YAML file requires Ansible version 2.1 or later.
-if [ ${ANSIBLE_MAJOR_VERSION} -le 2 -a ${ANSIBLE_MINOR_RELEASE} -lt 1 ]; then
+#if [ ${ANSIBLE_MAJOR_VERSION} -le 2 -a ${ANSIBLE_MINOR_RELEASE} -lt 1 ]; then
   # Old version of Ansible; install
-  sudo apt-get --yes update
-  sudo apt-get install --yes software-properties-common
-  sudo apt-add-repository --yes ppa:ansible/ansible
-  sudo apt-get --yes update
-  sudo apt-get install --yes ansible
-fi
+  #sudo apt-get --yes update
+  #sudo apt-get install --yes software-properties-common
+  #sudo apt-add-repository --yes ppa:ansible/ansible
+  #sudo apt-get --yes update
+  #sudo apt-get install --yes ansible
+#fi
 
 wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 
-sudo ansible-playbook --extra-vars=\"login=${VMUSER}\" --inventory localhost, --connection local ${TUFFIXYML}
+sudo ansible-playbook --extra-vars="login=${VMUSER}" --inventory localhost, --connection local ${TUFFIXYML}
 
 #rm -f ${TUFFIXYML}

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -23,7 +23,7 @@ fi
 
 sudo apt --yes install ansible wget
 
-wget -o ${TUFFIXYML} ${TUFFIXYML_SRC}
+wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 
 sudo ansible-playbook --extra-vars="login=${VMUSER}" --inventory localhost, --connection local ${TUFFIXYML}
 

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -9,6 +9,15 @@ if (( EUID == 0 )); then
     exit 1
 fi
 
+MAJOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 1 -d.`
+MINOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 2 -d.`
+if [ ${MAJOR_RELEASE} -lt 18 ]; then
+  echo "error: this is meant for Ubuntu 18.04 and later. Your release information is:"
+  lsb_release -a
+  exit 1
+fi
+
+
 VMUSER=${USER}
 
 if [ "${VMUSER}x" == "x" ]; then
@@ -16,28 +25,15 @@ if [ "${VMUSER}x" == "x" ]; then
   VMUSER=student
 fi
 
-sudo apt-get --yes update
-sudo apt-get install --yes software-properties-common
-sudo apt-add-repository --yes ppa:ansible/ansible
-sudo apt-get --yes update
-sudo apt-get install --yes ansible
-sudo apt-get install --yes wget
+# This was for installing the latest version of Ansible.
+#sudo apt-get --yes update
+#sudo apt-get install --yes software-properties-common
+#sudo apt-add-repository --yes ppa:ansible/ansible
+#sudo apt-get --yes update
+#sudo apt-get install --yes ansible
+#sudo apt-get install --yes wget
 
-
-#sudo apt --yes install ansible wget
-
-#ANSIBLE_MAJOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 1 -d.`
-#ANSIBLE_MINOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 2 -d.`
-
-# The tuffix YAML file requires Ansible version 2.1 or later.
-#if [ ${ANSIBLE_MAJOR_VERSION} -le 2 -a ${ANSIBLE_MINOR_RELEASE} -lt 1 ]; then
-  # Old version of Ansible; install
-  #sudo apt-get --yes update
-  #sudo apt-get install --yes software-properties-common
-  #sudo apt-add-repository --yes ppa:ansible/ansible
-  #sudo apt-get --yes update
-  #sudo apt-get install --yes ansible
-#fi
+sudo apt --yes install ansible wget
 
 wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -9,12 +9,6 @@ if (( EUID == 0 )); then
     exit 1
 fi
 
-if [ $# > 0 ]; then
-  VMUSER=student
-else
-  VMUSER=${USER}
-fi
-
 VMUSER=${USER}
 
 if [ "${VMUSER}x" == "x" ]; then

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -17,7 +17,7 @@ fi
 
 VMUSER=${USER}
 
-if [ "${VMUSER}x" -eq "x" ]; then
+if [ "${VMUSER}x" == "x" ]; then
   echo "Environment missing USER variable; using student."
   VMUSER=student
 fi

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -22,10 +22,19 @@ if [ "${VMUSER}x" == "x" ]; then
   VMUSER=student
 fi
 
+
 sudo apt --yes install ansible wget
+
+ANSIBLE_MAJOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 1 -d.`
+ANSIBLE_MINOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 2 -d.`
+
+# The tuffix YAML file requires Ansible version 2.1 or later.
+if [ ${ANSIBLE_MAJOR_VERSION} -le 2 -a ${ANSIBLE_MINOR_RELEASE} -lt 1 ]; then
+  # Old version of Ansible; install 
+fi
 
 wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 
 sudo ansible-playbook --extra-vars=\"login=${VMUSER}\" --inventory localhost, --connection local ${TUFFIXYML}
 
-rm -f ${TUFFIXYML}
+#rm -f ${TUFFIXYML}

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-TUFFIXYML_SRC="https://raw.githubusercontent.com/mshafae/tuffix/package-changes-mshafae/tuffix.yml"
+TUFFIXYML_SRC="https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml"
 
 TUFFIXYML=/tmp/tuffix.$$.yml
 
@@ -39,4 +39,4 @@ wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 
 sudo ansible-playbook --extra-vars="login=${VMUSER}" --inventory localhost, --connection local ${TUFFIXYML}
 
-#rm -f ${TUFFIXYML}
+rm -f ${TUFFIXYML}

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -26,6 +26,6 @@ sudo apt --yes install ansible wget
 
 wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 
-sudo ansible-playbook --extra-vars="login=${VMUSER}" --inventory localhost, --connection local ${TUFFIXYML}
+sudo ansible-playbook --extra-vars=\"login=${VMUSER}\" --inventory localhost, --connection local ${TUFFIXYML}
 
 rm -f ${TUFFIXYML}

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -1,6 +1,6 @@
 #! /bin/bash
 
-TUFFIXYML_SRC="https://raw.githubusercontent.com/kevinwortman/tuffix/master/tuffix.yml"
+TUFFIXYML_SRC="https://raw.githubusercontent.com/mshafae/tuffix/package-changes-mshafae/tuffix.yml"
 
 TUFFIXYML=/tmp/tuffix.$$.yml
 

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -30,7 +30,12 @@ ANSIBLE_MINOR_RELEASE=`ansible --version | head -1 | cut -f 2 -d\  | cut -f 2 -d
 
 # The tuffix YAML file requires Ansible version 2.1 or later.
 if [ ${ANSIBLE_MAJOR_VERSION} -le 2 -a ${ANSIBLE_MINOR_RELEASE} -lt 1 ]; then
-  # Old version of Ansible; install 
+  # Old version of Ansible; install
+  sudo apt-get --yes update
+  sudo apt-get install --yes software-properties-common
+  sudo apt-add-repository --yes ppa:ansible/ansible
+  sudo apt-get --yes update
+  sudo apt-get install --yes ansible
 fi
 
 wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}


### PR DESCRIPTION
The shell script is improved to check the Ubuntu release (important to ensure that the packages install correctly and versions match), the yaml file is saved to a temp. file in /tmp with a unique name, and the script now checks the user's name in case it is being used on a bare metal install.

The YAML file preemptively adds the vboxsf group and the current user to that group ahead of adding the VBox additions. Some of the packages have been removed or commented out. A new entry for CPSC 351 was added.

It's important to note that this ansible play book cannot be performed on Ubuntu 16.04 LTS unless the most recent version of ansible is installed. Additionally at least one of the packages (nlohmann-json-dev) is not available for 16.04.

The YAML source file can be overridden using the TUFFIXYML_SRC environment variable to aid in debugging.