### PR TITLE
Change full package of LaTeX to base one to speed up installation

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -276,7 +276,7 @@
   tasks:
 
     - name: LaTeX
-      apt: name=texlive-full state=present
+      apt: name=texlive-base state=present
 
 ###############################################################################
 # cleanup


### PR DESCRIPTION
The full package of LaTeX took about 20 minutes to install. It would be better to install the base one, which will speed up the configuration of Tuffix, especially for this upcoming Friday's Linuxfest.