### PR TITLE
Googletest fix

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -111,7 +111,7 @@
         - git
         - subversion
 
-    -name: googletest remove conflicting packages
+    - name: googletest remove conflicting packages
       apt: name={{item}} state=absent
       with_items:
         - googletest

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -111,6 +111,12 @@
         - git
         - subversion
 
+    -name: googletest remove conflicting packages
+      apt: name={{item}} state=absent
+      with_items:
+        - googletest
+        - libgtest-dev
+        
     - name: googletest dependencies
       apt: name={{item}} state=present
       with_items:


### PR DESCRIPTION
I've added a package removal step in case googletest or libgtest-dev were already installed on the virtual machine. This is what causes a segfault error when the newer version of googletest is compiled (used in my CPSC 121 lab exercises)

So far, I've tested this using an ubuntu and xubuntu virtual machine.

**How to replicate**
1. Install ubuntu/xubuntu on a virtual machine
1. Install googletest and libgtest-dev ```sudo apt install googletest libgtest-dev```
1. Run the tuffixize script (I kind of hacked this by running the ansible script directly as the script is not downloading the .yml file)
1. Clone, run, and execute the unit test for a CPSC 121 lab exercise (will need to automate this process as mentioned in #11)