### PR TITLE
Vagrant upgrade to Ubuntu 19.10

### DIFF
--- a/mini-tuffix.yml
+++ b/mini-tuffix.yml
@@ -1,0 +1,113 @@
+
+---
+
+#####################################################################
+# general configuration, not tied to any specific course
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: Update repositories cache and update all packages to the latest version
+      apt:
+        update_cache: yes
+        upgrade: dist
+
+    - name: Remove dependencies that are no longer required
+      apt:
+        autoremove: yes
+
+    - name: Ensure that the vboxsf group exists to premptively add the user to it.
+      group:
+        name: vboxsf
+        state: present
+
+#####################################################################
+# CPSC 120-121-131 official environment
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  vars:
+    login: student
+  tasks:
+
+    - name: clang toolchain
+      apt:
+        pkg:
+          - build-essential
+          - clang
+          - clang-tidy
+          - clang-format
+          - lldb
+
+    - name: g++ 9 compiler
+      apt:
+        pkg:
+          - build-essential
+          - gcc-9
+          - g++-9
+          - gdb
+
+    - name: Atom editor
+      apt: deb=https://atom.io/download/deb
+
+    - name: Atom gdb support
+      command: /usr/bin/apm install dbg-gdb dbg output-panel
+
+    # this playbook is run as root, so the apm command above
+    # creates a ~/.atom owned by root, so the student user does
+    # not have permissions into it, and Atom fails to load
+    # properly and shows a debug interface. This makes the
+    # directory owned by {{ login }}, by default `student`, thus
+    # solving the problem.
+    - name: atom owned by user instead of root
+      file:
+        path: ~/.atom
+        owner: "{{ login }}"
+        group: "{{ login }}"
+
+    - name: Adding current user {{ login }} to group vboxsf preemptively
+      user:
+        name: "{{ login }}"
+        groups: vboxsf
+        append: yes
+
+    - name: Google Test Package Install
+      apt:
+        pkg:
+          - libgtest-dev
+          - build-essential
+          - cmake
+          - clang
+          - gcc-9
+          - g++-9
+
+    - name: Google Test Library Build
+      shell: |
+        BUILDDIR="/tmp/gtestbuild.$$"
+        DESTROOT="/usr/local/"
+        mkdir -p ${BUILDDIR}
+        cd ${BUILDDIR}
+        cmake -DCMAKE_BUILD_TYPE=RELEASE /usr/src/gtest/
+        make
+        install -o root -g root -m 644 libgtest.a ${DESTROOT}/lib
+        install -o root -g root -m 644 libgtest_main.a ${DESTROOT}/lib
+
+
+#####################################################################
+# cleanup
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: apt clean
+      command: apt clean
+
+...

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -18,9 +18,8 @@ test_dns_web ( ){
 MAJOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 1 -d.`
 MINOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 2 -d.`
 if [ ${MAJOR_RELEASE} -lt 19 ]; then
-  echo "error: this is meant for Ubuntu 19.04 and later. Your release information is:"
+  echo "Warning: this is meant for Ubuntu 19.04 and later. Your release information is:"
   lsb_release -a
-  exit 1
 fi
 
 
@@ -38,7 +37,7 @@ fi
 test_dns_web
 
 sudo apt update
-sudo apt --yes install ansible wget aptitude python
+sudo apt --yes install ansible wget aptitude python python3-distutils
 
 REGEX='(https?)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
 
@@ -46,6 +45,7 @@ if [[ $TUFFIXYML_SRC =~ $REGEX ]]; then
   wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 else
   # Useful for debugging
+  echo "Overriding TUFFIXYML_SRC: ${TUFFIXYML_SRC}"
   cp ${TUFFIXYML_SRC} ${TUFFIXYML}
 fi
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,15 +2,18 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu1904"
-  config.vm.synced_folder "..", "/vagrant"
+  config.vm.box = "generic/ubuntu1910"
 
-   config.vm.provider "virtualbox" do |vb|
-     # Customize the amount of memory on the VM:
-     vb.memory = "512"
-   end
+  config.vm.synced_folder "..", "/tuffix"
+  config.vm.synced_folder Dir.home, "/hosthome"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory on the VM
+    vb.memory = "512"
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
-    TUFFIXYML_SRC="/vagrant/tuffix.yml"; export TUFFIXYML_SRC
-    bash /vagrant/tuffixize.sh
+    TUFFIXYML_SRC="/tuffix/tuffix.yml"; export TUFFIXYML_SRC
+    bash /tuffix/tuffixize.sh
   SHELL
 end


### PR DESCRIPTION
Tuffix repository is mounted to /tuffix
User's home directory (if detected by Ruby) mounts to /hosthome; the entire boot process will probably fail if the user doesn't have a home directory to share.
Added a smaller yml file for debugging purposes.
Vagrant file updated to use generic/ubuntu1910.