### PR TITLE
VM instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,7 +13,7 @@ code with one another.
 
 The major components of Tuffix are
 
-* Xubuntu 19.04
+* Xubuntu 19.10
 * clang compiler
 * GNU g++9 C++ compiler
 * Atom text editor
@@ -33,7 +33,7 @@ CSUF instructors: email Kevin Wortman and ask him to add you to the
 [Tuffix Instructors](https://communities.fullerton.edu/course/view.php?id=1544)
 community in Titanium.
 
-## Installation
+## Installation & Hardware Requirements
 
 See the [Tuffix Installation Instructions in install.md](install.md)
 

--- a/README.md
+++ b/README.md
@@ -35,11 +35,11 @@ community in Titanium.
 
 ## Installation
 
-See the [Tuffix Installation Instructions in install.md](https://github.com/kevinwortman/tuffix/blob/master/install.md)
+See the [Tuffix Installation Instructions in install.md](install.md)
 
 ## Building a Release VM
 
-See the [Tuffix VM Build Process in vm-build-process.md](https://github.com/kevinwortman/tuffix/blob/master/vm-build-process.md)
+See the [Tuffix VM Build Process in vm-build-process.md](vm-build-process.md)
 
 ## Acknowledgements
 

--- a/install.md
+++ b/install.md
@@ -56,7 +56,7 @@ You may self-enroll in the community; first login to your portal, then navigate 
 
 1. Install Xubuntu onto your computer. **All data on computer will be deleted forever including all your programs like Microsoft Word and Excel. You cannot reinstall these programs.** The steps are similar to the steps in the online [Install Ubuntu Desktop tutorial](https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop#3). You may need expert help on this step so please consult with your instructor.
 
-1. Reboot the computer and login. Setup WiFi - if you're using Eduroam, use the [Tuffix Eduroam Authentication Instructions](https://github.com/kevinwortman/tuffix/blob/master/eduroam.md).
+1. Reboot the computer and login. Setup WiFi - if you're using Eduroam, use the [Tuffix Eduroam Authentication Instructions](eduroam.md).
 
 1. Open a terminal window, and run the tuffixize.sh script (without using sudo):
 ```

--- a/install.md
+++ b/install.md
@@ -12,9 +12,29 @@ You can install Tuffix in two ways:
 
   1. **Virtual machine** (VM): as a VirtualBox virtual machine image running inside a Widows, MacOS, or Linux computer.
 
-Option 1 (native) is recommended for students because running natively allows Tuffix to make full use of your hardware, allowing software to run quickly and efficiently, and peripherals such as USB drives and wifi to work seamlessly. We recommend obtaining a laptop that runs Tuffix natively to use in your computer science courses.
+Option 1 (native) is *strongly recommended* for students because running natively allows Tuffix to make full use of your hardware, allowing software to run quickly and efficiently, and peripherals such as USB drives and wifi to work seamlessly. We recommend obtaining a laptop that runs Tuffix natively to use in your computer science courses.
 
-Option 2 (virtual machine) will be a clunkier experience, but may be more convenient because you can run Tuffix inside a computer you already own without permanently altering that computer. Since your computer’s RAM memory will be divided between the guest Tuffix OS, and your native host OS, memory will be scarce and programs may run slowly due to [paging and thrashing](https://en.wikipedia.org/wiki/Paging).
+If you do not have a computer that you can install Tuffix natively, then work with your instructor to borrow a laptop from the university. CSUF has a [long term laptop loan program](https://www.fullerton.edu/it/students/equipment/longtermlaptop.php) where a student can borrow a laptop for the duration of the semester. You will need to work with your instructor to request such a laptop. The sooner you make the request, the sooner you will have a laptop in your hands to run Tuffix natively! 
+
+The hardware requirements to run Tuffix natively are:
+* A recent 64bit Intel or AMD processor (Intel Core and Xeon series, AMD Athlon, Phenom, Opteron, Sempron, etc.)
+* At least 4 GB of RAM
+* At least 30 GB of hard disk or flash memory storage
+* WiFi or Ethernet
+
+The best laptops to buy are Lenovo Thinkpad T, X, and L series laptops. The best kind of laptop is one that you get for free. Look around and ask around, you may find an old laptop that is perfect for Tuffix. Chromebooks are not an option; most Dell laptops work well.
+
+Option 2 (virtual machine) is *strongly discouraged*. The experience will be slow and you will spend more time fighting your computer than learning computer science. If you are worried about damaging your computer or your files by installing Tuffix, then consider borrowing a laptop from CSUF's [long term laptop loan program](https://www.fullerton.edu/it/students/equipment/longtermlaptop.php).
+
+Be aware that your computer will need a lot of RAM to comfortably run a guest VM (Tuffix) alongside your host operating system (MS Windows or Apple macOS).
+
+The hardware requirements to run a Tuffix VM are:
+* A recent Intel or AMD processor that supports VT-X or AMD-V extensions
+* At least 8 GB of RAM
+* At least 30 GB of free hard disk or flash memory storage
+* WiFi or Ethernet
+
+Your processor must support the VT-x/AMD-V extension. If your processor supports these instructions yet does not allow you to boot the VM, then the instructions may be disabled from your computer's BIOS. Check the settings of your BIOS and, if needed, update your system's BIOS to enable the instructions.
 
 ## Tuffix Students Community
 
@@ -26,11 +46,11 @@ You may self-enroll in the community; first login to your portal, then navigate 
 
 1. Confirm that your computer meets the [Xubuntu system requirements](https://xubuntu.org/requirements/), and that you are ready to erase everything on the computer and replace it with Tuffix. You may want to check that your entire laptop, or at least its wifi card, are on the list of Ubuntu-certified hardware.
 
-1. Burn an ISO image to a USB memory stick to install Xubuntu. Download an Xubuntu 19.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
+1. Burn an ISO image to a USB memory stick to install Xubuntu. Download an Xubuntu 19.10 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
 
-    1. Go to http://mirror.us.leaseweb.net/ubuntu-cdimage/xubuntu/releases/ and look for `19.04`. Click the link and then click `release`.
+    1. Go to http://mirror.us.leaseweb.net/ubuntu-cdimage/xubuntu/releases/ and look for `19.10`. Click the link and then click `release`.
 
-    1. Download the file `xubuntu-19.04-desktop-amd64.iso`.
+    1. Download the file `xubuntu-19.10-desktop-amd64.iso`.
 
     1. Burn the ISO image to a USB memory stick that is at least 4 GB. **All data on the USB memory stick will be deleted forever.** Instructions on how to do this are online for [Ubuntu](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu#0), [macOS](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0), and [Windows](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows#0).
 
@@ -51,9 +71,9 @@ $ wget https://csufcs.com/tuffixize -O - | bash
 
 1. Install VirtualBox 6.0.10 on your host computer (at either https://www.virtualbox.org/wiki/Downloads or https://www.virtualbox.org/wiki/Download_Old_Builds_6_0).
 
-    - Apple computers with OS X 10.13 or later will encounter problems installing VirtualBox. If your installation failed, please see https://medium.com/@DMeechan/fixing-the-installation-failed-virtualbox-error-on-mac-high-sierra-7c421362b5b5. VirtualBox must be installed successfully first before moving on to the next step.
+    - Apple computers with OS X 10.13 or later will encounter problems installing VirtualBox. You must read every window that pops up very carefully. During the installation process you must go to the Security & Privacy control panel to allow VirtualBox to install. If you do not pay close attention you have a broken VirtualBox installation that will not work. Please read https://medium.com/@DMeechan/fixing-the-installation-failed-virtualbox-error-on-mac-high-sierra-7c421362b5b5 to get an idea of what the process is like before you attempt installing VirtualBox. *VirtualBox must be installed successfully first before moving on to the next step.*
 
-    - VirtualBox requires that the CPU virtualization feature is turned on in your BIOS settings. Most models of computer have this turned on by default, but some have it turned off. If VirtualBox gives errors about CPU virtualization, enter your BIOS settings and turn this feature on. You can usually find instructions by googling for "(computer model) enable  virtualization", for example "Lenovo Thinkpad T420 enable virtualization".
+    - VirtualBox requires that the CPU virtualization feature is turned on in your BIOS settings. Most models of computer have this turned on by default, but some have it turned off. If VirtualBox gives errors about CPU virtualization, enter your BIOS settings and turn this feature on. You can usually find instructions by googling for "(computer model) enable  virtualization", for example "Lenovo Thinkpad T420 enable virtualization". Your computer model is typically written on the sticker that is on the bottom of your laptop.
 
 1. The VM is intended to work with this specific version of VirtualBox, so you may experience compatibility problems if you use a different version. VirtualBox may ask you to upgrade to a newer version, but **do not upgrade VirtualBox** because that will cause the Guest Additions to stop working.
 

--- a/mini-tuffix.yml
+++ b/mini-tuffix.yml
@@ -1,0 +1,113 @@
+
+---
+
+#####################################################################
+# general configuration, not tied to any specific course
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: Update repositories cache and update all packages to the latest version
+      apt:
+        update_cache: yes
+        upgrade: dist
+
+    - name: Remove dependencies that are no longer required
+      apt:
+        autoremove: yes
+
+    - name: Ensure that the vboxsf group exists to premptively add the user to it.
+      group:
+        name: vboxsf
+        state: present
+
+#####################################################################
+# CPSC 120-121-131 official environment
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  vars:
+    login: student
+  tasks:
+
+    - name: clang toolchain
+      apt:
+        pkg:
+          - build-essential
+          - clang
+          - clang-tidy
+          - clang-format
+          - lldb
+
+    - name: g++ 9 compiler
+      apt:
+        pkg:
+          - build-essential
+          - gcc-9
+          - g++-9
+          - gdb
+
+    - name: Atom editor
+      apt: deb=https://atom.io/download/deb
+
+    - name: Atom gdb support
+      command: /usr/bin/apm install dbg-gdb dbg output-panel
+
+    # this playbook is run as root, so the apm command above
+    # creates a ~/.atom owned by root, so the student user does
+    # not have permissions into it, and Atom fails to load
+    # properly and shows a debug interface. This makes the
+    # directory owned by {{ login }}, by default `student`, thus
+    # solving the problem.
+    - name: atom owned by user instead of root
+      file:
+        path: ~/.atom
+        owner: "{{ login }}"
+        group: "{{ login }}"
+
+    - name: Adding current user {{ login }} to group vboxsf preemptively
+      user:
+        name: "{{ login }}"
+        groups: vboxsf
+        append: yes
+
+    - name: Google Test Package Install
+      apt:
+        pkg:
+          - libgtest-dev
+          - build-essential
+          - cmake
+          - clang
+          - gcc-9
+          - g++-9
+
+    - name: Google Test Library Build
+      shell: |
+        BUILDDIR="/tmp/gtestbuild.$$"
+        DESTROOT="/usr/local/"
+        mkdir -p ${BUILDDIR}
+        cd ${BUILDDIR}
+        cmake -DCMAKE_BUILD_TYPE=RELEASE /usr/src/gtest/
+        make
+        install -o root -g root -m 644 libgtest.a ${DESTROOT}/lib
+        install -o root -g root -m 644 libgtest_main.a ${DESTROOT}/lib
+
+
+#####################################################################
+# cleanup
+# point person: undergraduate committee
+#####################################################################
+
+- hosts: all
+  remote_user: root
+  tasks:
+
+    - name: apt clean
+      command: apt clean
+
+...

--- a/tuffixize.sh
+++ b/tuffixize.sh
@@ -18,9 +18,8 @@ test_dns_web ( ){
 MAJOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 1 -d.`
 MINOR_RELEASE=`lsb_release -r | cut -f 2 | cut -f 2 -d.`
 if [ ${MAJOR_RELEASE} -lt 19 ]; then
-  echo "error: this is meant for Ubuntu 19.04 and later. Your release information is:"
+  echo "Warning: this is meant for Ubuntu 19.04 and later. Your release information is:"
   lsb_release -a
-  exit 1
 fi
 
 
@@ -38,7 +37,7 @@ fi
 test_dns_web
 
 sudo apt update
-sudo apt --yes install ansible wget aptitude python
+sudo apt --yes install ansible wget aptitude python python3-distutils
 
 REGEX='(https?)://[-A-Za-z0-9\+&@#/%?=~_|!:,.;]*[-A-Za-z0-9\+&@#/%=~_|]'
 
@@ -46,6 +45,7 @@ if [[ $TUFFIXYML_SRC =~ $REGEX ]]; then
   wget -O ${TUFFIXYML} ${TUFFIXYML_SRC}
 else
   # Useful for debugging
+  echo "Overriding TUFFIXYML_SRC: ${TUFFIXYML_SRC}"
   cp ${TUFFIXYML_SRC} ${TUFFIXYML}
 fi
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,15 +2,18 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "generic/ubuntu1904"
-  config.vm.synced_folder "..", "/vagrant"
+  config.vm.box = "generic/ubuntu1910"
 
-   config.vm.provider "virtualbox" do |vb|
-     # Customize the amount of memory on the VM:
-     vb.memory = "512"
-   end
+  config.vm.synced_folder "..", "/tuffix"
+  config.vm.synced_folder Dir.home, "/hosthome"
+
+  config.vm.provider "virtualbox" do |vb|
+    # Customize the amount of memory on the VM
+    vb.memory = "512"
+  end
+
   config.vm.provision "shell", inline: <<-SHELL
-    TUFFIXYML_SRC="/vagrant/tuffix.yml"; export TUFFIXYML_SRC
-    bash /vagrant/tuffixize.sh
+    TUFFIXYML_SRC="/tuffix/tuffix.yml"; export TUFFIXYML_SRC
+    bash /tuffix/tuffixize.sh
   SHELL
 end


### PR DESCRIPTION
Added clearer instructions regarding the installation process and hardware requirements.

Made a reference to VT-X extensions and turning those on in the BIOS for VM users.

Discouraged the use of VMs.

Updated Xubuntu to 19.10.

Removed absolute links in Markdown files.