### PR TITLE
Vagrant GUI

### DIFF
--- a/vagrant/README.md
+++ b/vagrant/README.md
@@ -1,7 +1,10 @@
 # Vagrant VM
-This is the *right* way to run a Tuffix VM on your computer. It does not require too much memory (512 MB) and allows you to use all your regular Windows or Mac tools that you are used to. It is a lightweight way to have access to the Linux tools you need to get your class work completed.
+This is the *right* way to run a Tuffix virtual machine (VM) on your computer. The ideal use case is that the VM is run headless which means there is not a graphical user interface with windows and a mouse pointer. Files are shared between the host and the VM using the host's file system. To get work done, one uses all the typical Windows or Mac tools that one is used to. It is a lightweight way to have access to the Linux tools you need to get your class work completed.
 
 A short video that demonstrates basic use of this VM on a macOS host computer is online at https://youtu.be/xO3eSnkwk74.
+
+Optionally, the graphical desktop user interface can be used. This option is not recommended or encouraged.
+
 ## Prerequisites
 Windows and macOS users, first install [Vagrant](https://www.vagrantup.com/downloads.html).
 
@@ -13,17 +16,36 @@ Apple computers with macOS 10.13 or later will encounter problems installing Vir
 
 All the `vagrant` commands assume that you are in the same directory as the `Vagantfile` provided in this directory.
 
-## Starting the VM for the First Time
+## Headless VM - Default
+
+### Starting the VM for the First Time
 In this directory there is a file named `Vagrantfile`. If you have cloned this repository to your computer, navigate to this directory using a terminal program.
 
 To start the VM and provision it with the Tuffix software run `vagrant up --provision`. This process may take 10-40 minutes.
 
-## Logging into the VM
+### Logging into the VM
 The VM is headless and does not have a graphical user interface.
 
 In this directory there is a file named `Vagrantfile`. If you have cloned this repository to your computer, navigate to this directory using a terminal program.
 
 You can log into it by running the command `vagrant ssh`. If you want multiple ssh sessions, you may from another terminal navigate to the location of the `Vagrantfile` and run the command `vagrant ssh` again.
+
+## VM with Desktop Graphical User Interface - Optional
+
+A Graphical User Interface (GUI) is the sort of user interface you have when you use Windows or macOS. It uses the mouse and you can have multiple windows and applications visible.
+
+### Starting the VM for the First Time
+In this directory there is a file named `Vagrantfile`. If you have cloned this repository to your computer, navigate to this directory using a terminal program.
+
+To start the VM and provision it with the Tuffix software run `export VAGRANTGUI="YES" && vagrant up --provision`. This process may take 10-40 minutes.
+
+It will start up the VirtualBox hypervisor and start the desktop GUI.
+
+You can resize the size of the virtual screen by using the _Settings_ application from within Tuffix. Select the Display tab and change the resolution of the display.
+
+### Logging into the VM
+
+Starting up the VM will automatically log you in as the user `vagrant`.
 
 ## Stopping the VM
 In this directory there is a file named `Vagrantfile`. If you have cloned this repository to your computer, navigate to this directory using a terminal program.

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -2,9 +2,11 @@
 # vi: set ft=ruby :
 
 Vagrant.configure("2") do |config|
-  config.vm.box = "ubuntu/focal64"
-  #config.vm.box = "ubuntu/groovy64"
-
+  if ENV.has_key?('VAGRANTGUI')
+    config.vm.box = "fasmat/ubuntu2004-desktop"
+  else
+    config.vm.box = "ubuntu/focal64"
+  end
   config.vm.synced_folder "..", "/tuffix"
   config.vm.synced_folder Dir.home, "/hosthome"
 
@@ -13,11 +15,12 @@ Vagrant.configure("2") do |config|
     # You ought to be OK with 512 MB; increase if you need more.
     # Of course the problem is 512 MB is too little for Tuffixizing...Can't built Google Test.
     vb.memory = "2048"
+    vb.gui = true
   end
 
   config.vm.provision "shell", inline: <<-SHELL
     # If you have a local mirror, use the URL here
-    #TUFFIX_APT_SOURCES_HOSTURL="http://192.168.1.64/ubuntu"; export TUFFIX_APT_SOURCES_HOSTURL
+    TUFFIX_APT_SOURCES_HOSTURL="http://192.168.1.64/ubuntu"; export TUFFIX_APT_SOURCES_HOSTURL
     # If you'd like the change to be permanent, say YES
     #TUFFIX_APT_SOURCES_HOST_PERMANENT="YES"; export TUFFIX_APT_SOURCES_HOST_PERMANENT
     # Don't change this; it uses `config.vm.synced_folder "..", "/tuffix"`

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -22,7 +22,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.provision "shell", inline: <<-SHELL
     # If you have a local mirror, use the URL here
-    TUFFIX_APT_SOURCES_HOSTURL="http://192.168.1.64/ubuntu"; export TUFFIX_APT_SOURCES_HOSTURL
+    #TUFFIX_APT_SOURCES_HOSTURL="http://192.168.1.64/ubuntu"; export TUFFIX_APT_SOURCES_HOSTURL
     # If you'd like the change to be permanent, say YES
     #TUFFIX_APT_SOURCES_HOST_PERMANENT="YES"; export TUFFIX_APT_SOURCES_HOST_PERMANENT
     # Don't change this; it uses `config.vm.synced_folder "..", "/tuffix"`

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -15,7 +15,9 @@ Vagrant.configure("2") do |config|
     # You ought to be OK with 512 MB; increase if you need more.
     # Of course the problem is 512 MB is too little for Tuffixizing...Can't built Google Test.
     vb.memory = "2048"
-    vb.gui = true
+    if ENV.has_key?('VAGRANTGUI')
+      vb.gui = true
+    end
   end
 
   config.vm.provision "shell", inline: <<-SHELL


### PR DESCRIPTION
If the environment variable VAGRANTGUI is set, then the VM will have the default Ubuntu desktop. The dependency is on [fasmat/ubuntu2004-desktop](https://app.vagrantup.com/fasmat/boxes/ubuntu2004-desktop) box rather than the  [ubuntu/focal64 box](https://app.vagrantup.com/ubuntu/boxes/focal64).
Example command:
export VAGRANTGUI="YES" && vagrant up --provision