### PR TITLE
update ubuntu download link and filename

### DIFF
--- a/install.md
+++ b/install.md
@@ -56,9 +56,9 @@ Most of the challenges you will encounter have already been faced by your peers.
 
 1. Burn an ISO image to a USB memory stick to install Ubuntu. Download an Ubuntu 20.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
 
-    1. Go to https://mirror.math.princeton.edu/pub/ubuntu-iso/20.04.2/
+    1. Go to https://mirror.math.princeton.edu/pub/ubuntu-iso/20.04.3/
 
-    1. Download the file `ubuntu-20.04.2.0-desktop-amd64.iso`.
+    1. Download the file `ubuntu-20.04.3-desktop-amd64.iso`.
 
     1. Burn the ISO image to a USB memory stick that is at least 4 GB. **All data on the USB memory stick will be deleted forever.** Instructions on how to do this are online for [Ubuntu](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu#0), [macOS](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0), and [Windows](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows#0).
 


### PR DESCRIPTION
Princeton has replaced the 20.04.2 ISO on their host with the 20.04.3 ISO. The 20.04.2 ISO link no longer exists. The link for the ISO download has been updated, as well as the ISO name to the new 20.04.3 ISO.