### PR TITLE
Remove vm info

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,7 @@
 
+# Tuffix v. 1 is deprecated.
+Please visit [CSUF-Tuffix/Tuffix-2](https://github.com/CSUF-Tuffix/Tuffix-2) for more information.
+
 # tuffix: Tuffy's Linux
 
 Official Linux environment for CPSC 120, 121, and 131 at California

--- a/install.md
+++ b/install.md
@@ -52,62 +52,10 @@ There is a series of videos specifically made for installing and getting started
 
 Most of the challenges you will encounter have already been faced by your peers. Visit the [CSUF Tuffix Slack](https://csuf-tuffix.slack.com) channel to find valuable information that will help you complete your installation.
 
-1. Confirm that your computer meets the [Ubuntu system requirements](https://help.ubuntu.com/20.04/installation-guide/amd64/ch02.html), and that you are ready to erase everything on the computer and replace it with Tuffix. You may want to check that your entire laptop, or at least its wifi card, are on the list of Ubuntu-certified hardware.
-
-1. Burn an ISO image to a USB memory stick to install Ubuntu. Download an Ubuntu 20.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
-
-    1. Go to https://mirror.math.princeton.edu/pub/ubuntu-iso/20.04.3/
-
-    1. Download the file `ubuntu-20.04.3-desktop-amd64.iso`.
-
-    1. Burn the ISO image to a USB memory stick that is at least 4 GB. **All data on the USB memory stick will be deleted forever.** Instructions on how to do this are online for [Ubuntu](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu#0), [macOS](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0), and [Windows](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows#0).
-
-1. Install Ubuntu onto your computer. **All data on computer will be deleted forever including all your programs like Microsoft Word and Excel. You cannot reinstall these programs.** The steps are similar to the steps in the online [Install Ubuntu Desktop tutorial](https://tutorials.ubuntu.com/tutorial/tutorial-install-ubuntu-desktop#3). Please watch the [Tuffix installation videos](https://www.youtube.com/playlist?list=PL3LtnHvH0mFEUtiLHYAKEowJcqnZ4fZwP) and ask questions on the [CSUF Tuffix channel](https://csuf-tuffix.slack.com).
-
-1. Reboot the computer and login. Setup WiFi - if you're using Eduroam, use the [Tuffix Eduroam Authentication Instructions](eduroam.md). Please watch the [Tuffix installation videos](https://www.youtube.com/playlist?list=PL3LtnHvH0mFEUtiLHYAKEowJcqnZ4fZwP) and ask questions on the [CSUF Tuffix channel](https://csuf-tuffix.slack.com) if you need tips to get WiFi working on your computer.
-
-1. Open a terminal window, and run the tuffixize.sh script (without using sudo):
-   ```
-   $ wget https://csufcs.com/tuffixize -O - | bash
-   ```
-1. The script will ask for your password, and will install very many packages. The process may take up to an hour. It may ask for your password again depending how long this takes.
-
-1. Reboot your computer, and you’re done!
+_The old native install instructions were removed. Tuffix v.1 is deprecated. Please go to [CSUF-Tuffix](https://github.com/CSUF-Tuffix/Tuffix-2) for more information._
 
 ## Virtual Machine
 
-1. Install VirtualBox 6.1.12 on your host computer (at either https://www.virtualbox.org/wiki/Downloads or https://www.virtualbox.org/wiki/Download_Old_Builds_6_1).
+_The old VM instructions were removed. Tuffix v.1 is deprecated. Please go to [CSUF-Tuffix](https://github.com/CSUF-Tuffix/Tuffix-2) for more information._
 
-    - Apple computers with OS X 10.13 or later will encounter problems installing VirtualBox. If your installation failed, please see https://medium.com/@DMeechan/fixing-the-installation-failed-virtualbox-error-on-mac-high-sierra-7c421362b5b5. VirtualBox must be installed successfully first before moving on to the next step.
-
-    - VirtualBox requires that the CPU virtualization feature is turned on in your BIOS settings. Most models of computer have this turned on by default, but some have it turned off. If VirtualBox gives errors about CPU virtualization, enter your BIOS settings and turn this feature on. You can usually find instructions by googling for "(computer model) enable  virtualization", for example "Lenovo Thinkpad T420 enable virtualization".
-
-1. The VM is intended to work with this specific version of VirtualBox, so you may experience compatibility problems if you use a different version. VirtualBox may ask you to upgrade to a newer version, but **do not upgrade VirtualBox** because that will cause the Guest Additions to stop working.
-
-1. Download the .ova file from https://drive.google.com/file/d/1mbF4Y2sfWe7m409p0ejrof3kOmNJflVI/view.
-
-1. *(Recommended but not essential.)* Verify that the .ova downloaded completely, and was not tampered with, by checking its cryptographic hash. Compute a SHA-256 for your .ova and confirm that it matches: `ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02`.
-
-    1. On a Linux or Mac host, open a terminal window and use the shasum command:
-        ```
-        $ cd ~/Downloads
-        $ shasum --algorithm 256 "Tuffix 2020 Edition.ova"
-        ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02  Tuffix 2020 Edition.ova
-        ```
-
-    1. On Windows, open a Command Prompt window and use the CertUtil command:
-        ```
-        C:\>cd "%USERPROFILE%\Downloads" 
-        C:\Users\CSUFTitan\Downloads>CertUtil -hashfile "Tuffix 2020 Edition.ova" SHA256
-        SHA256 hash of Tuffix 2020 Edition.ova:
-        ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02
-        CertUtil: -hashfile command completed successfully.
-        ```
-
-    If the sum that is printed out does not match, that is an indication that either you did not actually download the entire file (most likely) or [hackers tampered with your download](https://en.wikipedia.org/wiki/Man-in-the-middle_attack) (only a remote possibility).
-
-1. In the VirtualBox user interface, Import the .ova file. This may take several minutes.
-
-1. Start the virtual machine, and login using username “student” and password “student”.
-
-There is a [Vagrantfile](vagrant/Vagrantfile) for those who know how to use [Vagrant](vagrantup.com).
+There is a [Vagrantfile](vagrant/Vagrantfile) for those who know how to use [Vagrant](https://www.vagrantup.com).


### PR DESCRIPTION
Pointed the reader to Tuffix v.2 repository on the README and removed the instructions for how to install. Pointed the reader to Tuffix v.2 from the install instructions.