### PR TITLE
eduroam.md 2022 update

### DIFF
--- a/eduroam.md
+++ b/eduroam.md
@@ -1,4 +1,4 @@
-# Eduroam WiFi Authentication Instructions
+# eduroam Wi-Fi Authentication Instructions
 
 Ask for assistance from a professor or a more experienced peer to help you if these instructions are not clear.
 
@@ -8,20 +8,20 @@ The instructions are valid as of Summer 2022.
 
 ## CSUF IT Wizard (recommended)
 
-CSUF's IT provides an online wizard for configuring Eduroam to download an executable to install the Eduroam wireless profile and CA Certificate.
+CSUF's IT provides an online wizard for configuring eduroam to download an executable to install the eduroam wireless profile and CA Certificate.
 
-The Online Wizard can be found at https://wireless.fullerton.edu/eduroam.php. Follow the steps provided to download and run the `SecureW2_JoinNow.run` executable to configure the Eduroam wireless profile.
+The Online Wizard can be found at https://wireless.fullerton.edu/eduroam.php. Follow the steps provided to download and run the `SecureW2_JoinNow.run` executable to configure the eduroam wireless profile.
 
 ## Manual Configuration (not recommended)
 
-Adding the Eduroam profile manually uses an inherently less secure method of authentication. If possible, the CSUF IT Wizard instructions above should be followed.
+Adding the eduroam profile manually uses an inherently less secure method of authentication. If possible, the CSUF IT Wizard instructions above should be followed.
 
-Make sure you type your username and password very carefully in the last two steps. This will save you time and avoid having something that looks right but it is broken.
-1. Go to the WiFi menu and choose 'Select Network'
+Make sure you type your username and password very carefully in the last two steps. This will save you time by avoiding creating something that looks right but is broken.
+1. Go to the Wi-Fi menu and choose 'Select Network'
 1. Select 'eduroam'; you may have to wait a minute for it to appear or select 'more networks' to see 'eduroam'. A window will appear where you can enter security and login information for eduroam.
-1. Look for the drop down menu labeled 'Authentication'. Change the value to 'Protected EAP (PEAP)'.
+1. Look for the drop-down menu labeled 'Authentication'. Change the value to 'Protected EAP (PEAP)'.
 1. Look for the checkbox that is labeled 'No CA certificate is required'. Check this box.
-1. Look for the drop down menu labeled 'Inner Authentication'. Make sure it is set to 'MSCHAPv2'.
+1. Look for the drop-down menu labeled 'Inner Authentication'. Make sure it is set to 'MSCHAPv2'.
 1. Look for the text box labeled 'Username'. In this text box enter your CSUF email address. For example, your email address looks like 'kai@csu.fullerton.edu'.
 1. Look for the text box labeled 'Password'. In this text box enter your CSUF portal password. **Make sure you type this password correctly. Please click 'Show Password' and verify your password.**
-1. The WiFi menu will refresh after a few minutes to show that you are connected to a network. Open your web browser and load up a web page such as http://www.fullerton.edu.
+1. The Wi-Fi menu will refresh after a few minutes to show that you are connected to a network. Open your web browser and load up a web page such as http://www.fullerton.edu.

--- a/eduroam.md
+++ b/eduroam.md
@@ -4,15 +4,18 @@ Ask for assistance from a professor or a more experienced peer to help you if th
 
 ## Version
 
-The instructions are valid as of Spring 2020.
+The instructions are valid as of Summer 2022.
 
-## CSUF IT Wizard
+## CSUF IT Wizard (recommended)
 
-CSUF's IT provides an online wizard for configuring Eduroam **Please don't use it.** Follow these instructions.
+CSUF's IT provides an online wizard for configuring Eduroam to download an executable to install the eduroam wireless profile and CA Certificate.
 
-If you have followed those instructions previously, please remove the Eduroam connection and then add it again. Ask for assistance if you don't know how to do this.
+The Online Wizard can be found at http://wireless.fullerton.edu/eduroam.php. Follow the steps provided to download and run the `SecureW2_JoinNow.run` executable to configure the eduroam wireless profile.
 
-## Adding Eduroam
+## Manual Configuration (not recommended)
+
+Adding the Eduroam profile manually uses an inherently less secure method of authentication. If possible, the CSUF IT Wizard instructions above should be followed.
+
 Make sure you type your username and password very carefully in the last two steps. This will save you time and avoid having something that looks right but it is broken.
 1. Go to the WiFi menu and choose 'Select Network'
 1. Select 'eduroam'; you may have to wait a minute for it to appear or select 'more networks' to see 'eduroam'. A window will appear where you can enter security and login information for eduroam.

--- a/eduroam.md
+++ b/eduroam.md
@@ -8,9 +8,9 @@ The instructions are valid as of Summer 2022.
 
 ## CSUF IT Wizard (recommended)
 
-CSUF's IT provides an online wizard for configuring Eduroam to download an executable to install the eduroam wireless profile and CA Certificate.
+CSUF's IT provides an online wizard for configuring Eduroam to download an executable to install the Eduroam wireless profile and CA Certificate.
 
-The Online Wizard can be found at http://wireless.fullerton.edu/eduroam.php. Follow the steps provided to download and run the `SecureW2_JoinNow.run` executable to configure the eduroam wireless profile.
+The Online Wizard can be found at https://wireless.fullerton.edu/eduroam.php. Follow the steps provided to download and run the `SecureW2_JoinNow.run` executable to configure the Eduroam wireless profile.
 
 ## Manual Configuration (not recommended)
 


### PR DESCRIPTION
Currently the eduroam wizard provided by CSUF IT is the preferred method of profile configuration. The currently listed instructions setup the Wi-Fi profile using PEAP-MSCHAPv2 whereas the wizard provided by IT (which has been tested and is functional) configures the Wi-Fi profile using TLS and a CA pub/PFX priv key combo which is inherently more secure.

I've updated the eduroam.md file containing basic instructions on how to obtain the eduroam wizard, as well as recommend it's use over the manual method. The old instruction remain under a new header containing a "not recommended" suggestion in the event manual setup of the eduroam profile is needed.