### PR TITLE
Remove Atom and Resolve GitHub CLI Issues

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -196,7 +196,7 @@
       shell: |
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
         chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        cho "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
     - name: Update repositories cache
       apt:

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -79,24 +79,6 @@
           - g++
           - gdb
 
-    - name: Atom editor
-      apt: deb=https://atom.io/download/deb
-
-    - name: Atom gdb support
-      command: /usr/bin/apm install dbg-gdb dbg output-panel
-
-    # this playbook is run as root, so the apm command above
-    # creates a ~/.atom owned by root, so the student user does
-    # not have permissions into it, and Atom fails to load
-    # properly and shows a debug interface. This makes the
-    # directory owned by {{ login }}, by default `student`, thus
-    # solving the problem.
-    - name: atom owned by user instead of root
-      file:
-        path: ~/.atom
-        owner: "{{ login }}"
-        group: "{{ login }}"
-
     - name: Adding current user {{ login }} to group vboxsf preemptively
       user:
         name: "{{ login }}"

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -197,6 +197,8 @@
         curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
         chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
         echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+      args:
+        warn: false
 
     - name: Update repositories cache
       apt:

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -194,8 +194,9 @@
 
     - name: gh client distribution URI as package source (i386, amd64, arm64)
       shell: |
-        apt-key adv --keyserver keyserver.ubuntu.com --recv-key C99B11DEB97541F0
-        apt-add-repository https://cli.github.com/packages
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        cho "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
 
     - name: Update repositories cache
       apt:


### PR DESCRIPTION
This pull request is from two branches. The first branch removed the Atom installation (since it's no longer needed, and resolve some warnings/errors) as well as fixing the GitHub CLI issues. The way the package signing changed would cause a failure after running the installation script. I updated the installation steps to reflect the current GitHub CLI installation [here](https://github.com/cli/cli/blob/trunk/docs/install_linux.md).

I did disable warning on the curl execution just so the end user doesn't have to see the big message regarding curl's use instead of get_url or get_uri. In the future it might be more appropriate to revise that method.