### PR TITLE
Upgrade to Ubuntu 22.04

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,11 +13,11 @@ code with one another.
 
 The major components of Tuffix are
 
-* Ubuntu 20.04
+* Ubuntu 22.04
 * clang compiler
 * GNU g++9 C++ compiler
-* Atom text editor
-* gdb debugger and Atom's dgb-gdb frontend
+* VisualStudio Code editor
+* GitHub CLI
 
 Additional tools and libraries are also included to support rich
 programming assignments, and courses aside from 120-121-131.

--- a/install.md
+++ b/install.md
@@ -54,9 +54,9 @@ Most of the challenges you will encounter have already been faced by your peers.
 
 1. Confirm that your computer meets the [Ubuntu system requirements](https://help.ubuntu.com/community/Installation/SystemRequirements), and that you are ready to erase everything on the computer and replace it with Tuffix. You may want to check that your entire laptop, or at least its wifi card, are on the list of Ubuntu-certified hardware.
 
-1. Burn an ISO image to a USB memory stick to install Ubuntu. Download an Ubuntu 20.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
+1. Burn an ISO image to a USB memory stick to install Ubuntu. Download an Ubuntu 22.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
 
-    1. Go to https://releases.ubuntu.com/22.04/ubuntu-22.04.1-desktop-amd64.iso
+    1. Go to https://releases.ubuntu.com/22.04/
 
     1. Download the file `ubuntu-22.04.1-desktop-amd64.iso`.
 
@@ -80,13 +80,13 @@ Most of the challenges you will encounter have already been faced by your peers.
 
     - Apple computers with OS X 10.13 or later will encounter problems installing VirtualBox. If your installation failed, please see https://medium.com/@DMeechan/fixing-the-installation-failed-virtualbox-error-on-mac-high-sierra-7c421362b5b5. VirtualBox must be installed successfully first before moving on to the next step.
 
-    - Apple M1 Computers are unable to efficiently emulate the x86 instruction set and additional steps will need to be taken to emulate that platform
+    - Apple M1 Computers are ARM based and are not supported for native or VM based Tuffix installations
 
     - VirtualBox requires that the CPU virtualization feature is turned on in your BIOS settings. Most models of computer have this turned on by default, but some have it turned off. If VirtualBox gives errors about CPU virtualization, enter your BIOS settings and turn this feature on. You can usually find instructions by googling for "(computer model) enable  virtualization", for example "Lenovo Thinkpad T420 enable virtualization".
 
 1. The VM is intended to work with this specific version of VirtualBox, so you may experience compatibility problems if you use a different version. VirtualBox may ask you to upgrade to a newer version, but **do not upgrade VirtualBox** because that will cause the Guest Additions to stop working.
 
-1. Download the .ova file from https://drive.google.com/file/d/1AM8qoVylAhZ_Rt98d_UtdTAPPbuqmHyT/view.
+1. Download the [Tuffix 2022 Edition](https://drive.google.com/file/d/1AM8qoVylAhZ_Rt98d_UtdTAPPbuqmHyT/view) .ova file Google Drive.
 
 1. *(Recommended but not essential.)* Verify that the .ova downloaded completely, and was not tampered with, by checking its cryptographic hash. Compute a SHA-256 for your .ova and confirm that it matches: `f09956e248a44476403e659a08e8dbf0ff9dd65bda4eaefc4157c8b555ea4ba2`.
 

--- a/install.md
+++ b/install.md
@@ -2,7 +2,7 @@
 
 ## Version
 
-This is the process for the **Tuffix 2020 release**.
+This is the process for the **Tuffix 2022 release**.
 
 ## Type of Install
 
@@ -52,13 +52,13 @@ There is a series of videos specifically made for installing and getting started
 
 Most of the challenges you will encounter have already been faced by your peers. Visit the [CSUF Tuffix Slack](https://csuf-tuffix.slack.com) channel to find valuable information that will help you complete your installation.
 
-1. Confirm that your computer meets the [Ubuntu system requirements](https://help.ubuntu.com/20.04/installation-guide/amd64/ch02.html), and that you are ready to erase everything on the computer and replace it with Tuffix. You may want to check that your entire laptop, or at least its wifi card, are on the list of Ubuntu-certified hardware.
+1. Confirm that your computer meets the [Ubuntu system requirements](https://help.ubuntu.com/community/Installation/SystemRequirements), and that you are ready to erase everything on the computer and replace it with Tuffix. You may want to check that your entire laptop, or at least its wifi card, are on the list of Ubuntu-certified hardware.
 
 1. Burn an ISO image to a USB memory stick to install Ubuntu. Download an Ubuntu 20.04 64-bit ISO image from an Ubuntu mirror site. (You may skip this step if you ask your instructor for a pre-made USB memory stick or attend an ACM Linux Installfest.)
 
-    1. Go to https://old-releases.ubuntu.com/releases/20.04/ubuntu-20.04.4-desktop-amd64.iso
+    1. Go to https://releases.ubuntu.com/22.04/ubuntu-22.04.1-desktop-amd64.iso
 
-    1. Download the file `ubuntu-20.04.4-desktop-amd64.iso`.
+    1. Download the file `ubuntu-22.04.1-desktop-amd64.iso`.
 
     1. Burn the ISO image to a USB memory stick that is at least 4 GB. **All data on the USB memory stick will be deleted forever.** Instructions on how to do this are online for [Ubuntu](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-ubuntu#0), [macOS](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-macos#0), and [Windows](https://tutorials.ubuntu.com/tutorial/tutorial-create-a-usb-stick-on-windows#0).
 

--- a/install.md
+++ b/install.md
@@ -76,31 +76,33 @@ Most of the challenges you will encounter have already been faced by your peers.
 
 ## Virtual Machine
 
-1. Install VirtualBox 6.1.12 on your host computer (at either https://www.virtualbox.org/wiki/Downloads or https://www.virtualbox.org/wiki/Download_Old_Builds_6_1).
+1. Install VirtualBox 6.1.34 on your host computer (at either https://www.virtualbox.org/wiki/Downloads or https://www.virtualbox.org/wiki/Download_Old_Builds_6_1).
 
     - Apple computers with OS X 10.13 or later will encounter problems installing VirtualBox. If your installation failed, please see https://medium.com/@DMeechan/fixing-the-installation-failed-virtualbox-error-on-mac-high-sierra-7c421362b5b5. VirtualBox must be installed successfully first before moving on to the next step.
+
+    - Apple M1 Computers are unable to efficiently emulate the x86 instruction set and additional steps will need to be taken to emulate that platform
 
     - VirtualBox requires that the CPU virtualization feature is turned on in your BIOS settings. Most models of computer have this turned on by default, but some have it turned off. If VirtualBox gives errors about CPU virtualization, enter your BIOS settings and turn this feature on. You can usually find instructions by googling for "(computer model) enable  virtualization", for example "Lenovo Thinkpad T420 enable virtualization".
 
 1. The VM is intended to work with this specific version of VirtualBox, so you may experience compatibility problems if you use a different version. VirtualBox may ask you to upgrade to a newer version, but **do not upgrade VirtualBox** because that will cause the Guest Additions to stop working.
 
-1. Download the .ova file from https://drive.google.com/file/d/1mbF4Y2sfWe7m409p0ejrof3kOmNJflVI/view.
+1. Download the .ova file from https://drive.google.com/file/d/1AM8qoVylAhZ_Rt98d_UtdTAPPbuqmHyT/view.
 
-1. *(Recommended but not essential.)* Verify that the .ova downloaded completely, and was not tampered with, by checking its cryptographic hash. Compute a SHA-256 for your .ova and confirm that it matches: `ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02`.
+1. *(Recommended but not essential.)* Verify that the .ova downloaded completely, and was not tampered with, by checking its cryptographic hash. Compute a SHA-256 for your .ova and confirm that it matches: `f09956e248a44476403e659a08e8dbf0ff9dd65bda4eaefc4157c8b555ea4ba2`.
 
     1. On a Linux or Mac host, open a terminal window and use the shasum command:
         ```
         $ cd ~/Downloads
-        $ shasum --algorithm 256 "Tuffix 2020 Edition.ova"
-        ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02  Tuffix 2020 Edition.ova
+        $ shasum --algorithm 256 "Tuffix 2022 Edition.ova"
+        f09956e248a44476403e659a08e8dbf0ff9dd65bda4eaefc4157c8b555ea4ba2  Tuffix 2022 Edition.ova
         ```
 
     1. On Windows, open a Command Prompt window and use the CertUtil command:
         ```
         C:\>cd "%USERPROFILE%\Downloads" 
-        C:\Users\CSUFTitan\Downloads>CertUtil -hashfile "Tuffix 2020 Edition.ova" SHA256
-        SHA256 hash of Tuffix 2020 Edition.ova:
-        ee3e88cc01b748e6422037c8a2854f44378403c8608c44c3f8f91be3c4d5db02
+        C:\Users\CSUFTitan\Downloads>CertUtil -hashfile "Tuffix 2022 Edition.ova" SHA256
+        SHA256 hash of Tuffix 2022 Edition.ova:
+        f09956e248a44476403e659a08e8dbf0ff9dd65bda4eaefc4157c8b555ea4ba2
         CertUtil: -hashfile command completed successfully.
         ```
 

--- a/install.md
+++ b/install.md
@@ -28,6 +28,8 @@ Option 2 (virtual machine) is *strongly discouraged*. The experience will be slo
 
 Be aware that your computer will need a lot of RAM to comfortably run a guest VM (Tuffix) alongside your host operating system (MS Windows or Apple macOS).
 
+Apple M1 Computers are ARM based and do not support native or VM based Tuffix installations. If you have a M1 based Apple computer, consider borrowing a laptop from CSUF's [long term laptop loan program](https://www.fullerton.edu/it/students/equipment/longtermlaptop.php).
+
 The hardware requirements to run a Tuffix VM are:
 * A recent Intel or AMD processor that supports VT-X or AMD-V extensions
 * At least 8 GB of RAM

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -69,6 +69,7 @@
           - clang-13
           - clang-tidy-13
           - clang-format-13
+          - clang
           - lldb
 
     - name: G++ compiler (default version for target Ubuntu release)

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -66,9 +66,9 @@
       apt:
         pkg:
           - build-essential
-          - clang
-          - clang-tidy
-          - clang-format
+          - clang-13
+          - clang-tidy-13
+          - clang-format-13
           - lldb
 
     - name: G++ compiler (default version for target Ubuntu release)

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -7,14 +7,14 @@ only need to be followed by the instructors who create the release VM.
 1. On host OS
   - Install/upgrade VirtualBox, using the specific version stated in
     the installation instructions. As of this writing, that is
-    **6.1.12**, at either https://www.virtualbox.org/wiki/Downloads or
+    **6.1.34**, at either https://www.virtualbox.org/wiki/Downloads or
     https://www.virtualbox.org/wiki/Download_Old_Builds_6_1.
   - Download the latest vanilla Ubuntu 64-bit LTS release .iso file, as of
-    this writing **ubuntu-20.04.1-desktop-amd64.iso**
+    this writing **ubuntu-22.04.1-desktop-amd64.iso**
     (https://ubuntu.com/download/desktop).
 2. In VirtualBox on the host computer
   - New VM
-    - Name: **Tuffix 2020 Edition**
+    - Name: **Tuffix 2022 Edition**
     - Type: Linux
     - Version: Ubuntu (64-bit)
     - Memory: 2048 MB
@@ -48,6 +48,7 @@ only need to be followed by the instructors who create the release VM.
     - Spring 2019: [Tuffix Background v3.3 1920x1080 - Jeffrey Lo.png](https://drive.google.com/open?id=16aBkkGTcgG40m4ayiuGNYbLM5BmDVjEC)
     - 2019 Edition: [Wallpaper Tux meets Tuffy - Brenda Valls - Edited.jpg](https://drive.google.com/open?id=1xKmzS8ilw-c1jdHSIQhd4j1mi36blIBC)
     - 2020 Edition: https://photos.app.goo.gl/ERwsA2urLqh1JYFX8
+    - 2022 Edition: [It Takes A Titan 2022](https://photos.google.com/photo/AF1QipPrJVTRXTnD76sZZe9jRR8Bfsut9gboFPyFUTlT)
     - **pick a new image for each release**
   - Update all packages
   ```
@@ -80,13 +81,13 @@ only need to be followed by the instructors who create the release VM.
 8. Final check
   - Create snapshot
   - Start VM
-  - Check that Atom can start, fullscreen window works, Firefox has no history
+  - Check that VisualStudio Code can start, fullscreen window works, Firefox has no history
   - Shut down
   - Restore the snapshot
 9. Create .ova and checksum
   - VirtualBox > File > Export Appliance
     (this takes a few minutes)
-  - `$ shasum -a 256 "Tuffix 2020 Edition.ova"`
+  - `$ shasum -a 256 "Tuffix 2022 Edition.ova"`
   - Upload the .ova to Google Drive
 10. Publish
   - Upload the .ova to Google Drive, and set the file's sharing settings to

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -75,9 +75,9 @@ only need to be followed by the instructors who create the release VM.
   - Mount the data partition to a temp location (i.e. `sudo mount /dev/sda3 /mnt/tmp`)
   - Assuming you've mounted /dev/sdaX to /mnt/tmp, the home directory `~` will be located at `/mnt/tmp/home/student`
     - Delete the wallpaper image from the Downloads folder `~/Downloads/itat.jpg`
-    - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`(this provided the Firefox Out-Of-Box experience next launch)
-    - Delete the `~/.bash_history` file on the data partition
-  - Run zerofree against the data partition
+    - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`(this provides the Firefox Out-Of-Box experience next launch)
+    - Delete the `~/.bash_history`
+  - Run zerofree against the data partition (/dev/sda3 is the data partition in the example below)
   ```
   $ sudo apt install zerofree
   $ sudo zerofree -v /dev/sda3

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -75,8 +75,7 @@ only need to be followed by the instructors who create the release VM.
   - Mount the data partition to a temp location (i.e. `sudo mount /dev/sda3 /mnt/tmp`)
   - Assuming you've mounted /dev/sdaX to /mnt/tmp, the home directory `~` will be located at `/mnt/tmp/home/student`
     - Delete the wallpaper image from the Downloads folder `~/Downloads/itat.jpg`
-    - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`
-    - (we delete the contents of `~/snap/firefox/common/.mozilla/firefox` so that students won't see this step in their browsing history)
+    - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`(this provided the Firefox Out-Of-Box experience next launch)
     - Delete the `~/.bash_history` file on the data partition
   - Run zerofree against the data partition
   ```

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -42,14 +42,16 @@ only need to be followed by the instructors who create the release VM.
   - *(let it finish, remove optical disk, restart)*
 4. Inside Ubuntu/Tuffix guest
   - Login as student
-  - Use Firefox to download a background image, move it to to `~/Pictures`, set it as the desktop wallpaper, delete `~/.mozilla`
-    - (we delete `~/.mozilla` so that students won't see this step in their browsing history)
+  - Use Firefox to download a background image and set it as the desktop wallpaper (it will automatically create a ~/Pictures/Wallpapers folder and copy the image there).
     - Fall 2018: [Tuffix-Background-v2-1920x1080 - Jeffrey Lo.png](https://drive.google.com/open?id=1QFt8kOPKjpd18fjnDWEVCxVmi4512xNy)
     - Spring 2019: [Tuffix Background v3.3 1920x1080 - Jeffrey Lo.png](https://drive.google.com/open?id=16aBkkGTcgG40m4ayiuGNYbLM5BmDVjEC)
     - 2019 Edition: [Wallpaper Tux meets Tuffy - Brenda Valls - Edited.jpg](https://drive.google.com/open?id=1xKmzS8ilw-c1jdHSIQhd4j1mi36blIBC)
     - 2020 Edition: https://photos.app.goo.gl/ERwsA2urLqh1JYFX8
     - 2022 Edition: [It Takes A Titan 2022](https://photos.app.goo.gl/RMreewgpA7ZQSQv58)
     - **pick a new image for each release**
+  - Delete the image from the Downloads folder
+  - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`
+    - (we delete the contents of `~/snap/firefox/common/.mozilla/firefox` so that students won't see this step in their browsing history)
   - Update all packages
   ```
   $ sudo apt update

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -48,7 +48,7 @@ only need to be followed by the instructors who create the release VM.
     - Spring 2019: [Tuffix Background v3.3 1920x1080 - Jeffrey Lo.png](https://drive.google.com/open?id=16aBkkGTcgG40m4ayiuGNYbLM5BmDVjEC)
     - 2019 Edition: [Wallpaper Tux meets Tuffy - Brenda Valls - Edited.jpg](https://drive.google.com/open?id=1xKmzS8ilw-c1jdHSIQhd4j1mi36blIBC)
     - 2020 Edition: https://photos.app.goo.gl/ERwsA2urLqh1JYFX8
-    - 2022 Edition: [It Takes A Titan 2022](https://photos.google.com/photo/AF1QipPrJVTRXTnD76sZZe9jRR8Bfsut9gboFPyFUTlT)
+    - 2022 Edition: [It Takes A Titan 2022](https://photos.app.goo.gl/RMreewgpA7ZQSQv58)
     - **pick a new image for each release**
   - Update all packages
   ```

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -49,9 +49,6 @@ only need to be followed by the instructors who create the release VM.
     - 2020 Edition: https://photos.app.goo.gl/ERwsA2urLqh1JYFX8
     - 2022 Edition: [It Takes A Titan 2022](https://photos.app.goo.gl/RMreewgpA7ZQSQv58)
     - **pick a new image for each release**
-  - Delete the image from the Downloads folder
-  - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`
-    - (we delete the contents of `~/snap/firefox/common/.mozilla/firefox` so that students won't see this step in their browsing history)
   - Update all packages
   ```
   $ sudo apt update
@@ -71,12 +68,20 @@ only need to be followed by the instructors who create the release VM.
     that the desktop resizes accordingly
 7. Zerofree
   - (this step makes the .ova file substantially smaller, thereby faster to download)
-  - Shut down VM
+  - Shut down the VM
   - Insert Ubuntu CD image again
   - Start VM > boot from CD > Try Ubuntu > terminal
+  - Identify the data partition (largest partition, usually /dev/sda3)
+  - Mount the data partition to a temp location (i.e. `sudo mount /dev/sda3 /mnt/tmp`)
+  - Assuming you've mounted /dev/sdaX to /mnt/tmp, the home directory `~` will be located at `/mnt/tmp/home/student`
+    - Delete the wallpaper image from the Downloads folder `~/Downloads/itat.jpg`
+    - Delete the contents of `~/snap/firefox/common/.mozilla/firefox`
+    - (we delete the contents of `~/snap/firefox/common/.mozilla/firefox` so that students won't see this step in their browsing history)
+    - Delete the `~/.bash_history` file on the data partition
+  - Run zerofree against the data partition
   ```
   $ sudo apt install zerofree
-  $ sudo zerofree -v /dev/sda1
+  $ sudo zerofree -v /dev/sda3
   ```
   (this takes several minutes)
   - Shut down, including ejecting the Ubuntu CD

--- a/vm-build-process.md
+++ b/vm-build-process.md
@@ -47,7 +47,7 @@ only need to be followed by the instructors who create the release VM.
     - Spring 2019: [Tuffix Background v3.3 1920x1080 - Jeffrey Lo.png](https://drive.google.com/open?id=16aBkkGTcgG40m4ayiuGNYbLM5BmDVjEC)
     - 2019 Edition: [Wallpaper Tux meets Tuffy - Brenda Valls - Edited.jpg](https://drive.google.com/open?id=1xKmzS8ilw-c1jdHSIQhd4j1mi36blIBC)
     - 2020 Edition: https://photos.app.goo.gl/ERwsA2urLqh1JYFX8
-    - 2022 Edition: [It Takes A Titan 2022](https://photos.app.goo.gl/RMreewgpA7ZQSQv58)
+    - 2022 Edition: [It Takes A Titan 2022](https://drive.google.com/file/d/1ZJbahygKCFb0ymPJ5p02GjieyPdHu5g8/view)
     - **pick a new image for each release**
   - Update all packages
   ```


### PR DESCRIPTION
While some commits contain changes as simple as typos, I tried my best to keep each commit to a feature change and providing a descriptive title. 

The summary of changes are:
Update all links/reference to Ubuntu 20.04, which consists of the ReadMe, Installation Instructions, and the VM build guide.

In addition to the wording change, I also updated the cleanup instructions within the VM build guide. Originally the only cleanup step was to remove the ~/.mozilla directory (which the location changed in 22.04) so I've updated the steps to reflect the new directory but I've moved the cleanup steps to _during_ the zerofree process. I did this so you can also clear the ~/.bash_history file at the same time, as well as the original wallpaper download. This consolidates all cleanup steps into one section.

I've also create a new .ova and updated the VM installation instructions to reflect the new hash. It was generated following my updated instructions and a new wallpaper was used (and the updated link is included).

I also included a disclaimer in the VM installation section about Apple M1 chips. While you can emulate on M1 using UTM, it's complicated and would require a whole separate set of instructions. 