### PR TITLE
install latest clang

### DIFF
--- a/tuffix.yml
+++ b/tuffix.yml
@@ -68,9 +68,8 @@
         pkg:
           - build-essential
           - clang-13
-          - clang-tidy-13
-          - clang-format-13
-          - clang
+          - clang-tidy
+          - clang-format
           - lldb
 
     - name: G++ compiler (default version for target Ubuntu release)

--- a/tuffix.yml
+++ b/tuffix.yml
@@ -67,7 +67,7 @@
       apt:
         pkg:
           - build-essential
-          - clang-13
+          - clang
           - clang-tidy
           - clang-format
           - lldb


### PR DESCRIPTION
originally installing latest clang, installation held at 13 due to linter issue. returning to standard clang installation as linter is being revised to not rely on deprecated features